### PR TITLE
Connection header fix for WebSocket

### DIFF
--- a/meinheld/server/response.c
+++ b/meinheld/server/response.c
@@ -622,7 +622,9 @@ write_headers(client_t *client, char *data, size_t datalen, char is_file)
         }
     }
 
-    if(client->keep_alive == 1){
+    if(client->status_code == 101){
+        add_header(bucket, "Connection", 10, "upgrade", 7);
+    }else if(client->keep_alive == 1){
         //Keep-Alive
         add_header(bucket, "Connection", 10, "Keep-Alive", 10);
     }else{


### PR DESCRIPTION
I have supressed the sending of `Connection: keep-alive` and `Connection: close` header values for the specific case of response status `101 Switching Protocols` to send `Connection: upgrade` instead. This is likely to better conform to the HTTP/1.1 and WebSocket specifications.

I did this to (in the near future) remove the weird workaround in current WebSocket middleware, which accesses the underlying connection to send the corrected header values.
