### PR TITLE
Fix crash caused by greenlet 0.4.5

### DIFF
--- a/meinheld/server/server.c
+++ b/meinheld/server/server.c
@@ -713,7 +713,6 @@ call_wsgi_handler(client_t *client)
 #ifdef WITH_GREENLET
     //new greenlet
     greenlet = greenlet_new(handler, NULL);
-    Py_DECREF(greenlet_getparent(greenlet));
     // set_greenlet
     pyclient->greenlet = greenlet;
     Py_INCREF(pyclient->greenlet);
@@ -2346,7 +2345,6 @@ meinheld_spawn(PyObject *self, PyObject *args, PyObject *kwargs)
     if (greenlet == NULL) {
         return NULL;
     }
-    Py_DECREF(greenlet_getparent(greenlet));
     res = internal_schedule_call(0, func, func_args, func_kwargs, greenlet);
     Py_XDECREF(res);
     DEBUG("greenlet refcnt:%d", (int)Py_REFCNT(greenlet));

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ else:
     define_macros=[
             ("WITH_GREENLET",None),
             ("HTTP_PARSER_DEBUG", "0") ]
-    install_requires=['greenlet>=0.4.0,<0.4.5']
+    install_requires=['greenlet>=0.4.5,<0.5']
 
 if develop:
     define_macros.append(("DEVELOP",None))


### PR DESCRIPTION
greenlet 0.4.5 fixes double incref when `greenlet_new(x, NULL)`
python-greenlet/greenlet@da73bfd11

greenlet_getcurrent() どう考えても borrowed reference 返すべきなのに new reference 返すというクソ仕様で、そのせいで greenlet_new の第二引数が NULL の時に greenlet_setparent(g, greenlet_getcurrent()) が current greenlet を2回 incref しちゃうというバグがあって、 meinheld は decref することで回避していた。

greenlet 0.4.5 で、 getcurrent() が borrowed reference 返すようにするのはさすがにAPI互換性的に無理だったのか、 greenlet_new の中で setparent を呼び出さないことで incref を2回してしまう問題だけ修正されてた。
