### PR TITLE
Revert "Use EPOLLEXCLUSIVE"

### DIFF
--- a/example/fork_sample.py
+++ b/example/fork_sample.py
@@ -6,10 +6,10 @@ workers = []
 
 def hello_world(environ, start_response):
     status = '200 OK'
-    res = b"Hello world!"
-    response_headers = [('Content-type', 'text/plain'), ('Content-Length', str(len(res)))]
+    res = "Hello world!"
+    response_headers = [('Content-type','text/plain'),('Content-Length',str(len(res)))]
     start_response(status, response_headers)
-    #print(environ)
+#    print environ
     return [res]
 
 def run(app, i):
@@ -31,3 +31,8 @@ meinheld.set_access_logger(None)
 meinheld.set_error_logger(None)
 meinheld.listen(("0.0.0.0", 8000))
 start()
+
+
+
+
+

--- a/meinheld/server/picoev_epoll.c
+++ b/meinheld/server/picoev_epoll.c
@@ -38,14 +38,6 @@
 # define PICOEV_EPOLL_DEFER_DELETES 1
 #endif
 
-// EPOLLEXCLUSIVE was added in Linux 4.5
-// When using backported (new) kernel, kernel supports it in spite of
-// sys/epoll.h doesn't define it.
-// Kernel older than 4.5 ignores this flag.  So we can pass it safely.
-#ifndef EPOLLEXCLUSIVE
-#define EPOLLEXCLUSIVE  (1 << 28)
-#endif
-
 typedef struct picoev_loop_epoll_st {
   picoev_loop loop;
   int epfd;
@@ -114,7 +106,7 @@ int picoev_update_events_internal(picoev_loop* _loop, int fd, int events)
   } while (0)
   
 #if PICOEV_EPOLL_DEFER_DELETES
-
+  
   if ((events & PICOEV_DEL) != 0) {
     /* nothing to do */
   } else if ((events & PICOEV_READWRITE) == 0) {
@@ -123,7 +115,6 @@ int picoev_update_events_internal(picoev_loop* _loop, int fd, int events)
     SET(EPOLL_CTL_MOD, 0);
     if (epoll_ret != 0) {
       assert(errno == ENOENT);
-      ev.events |= EPOLLEXCLUSIVE;
       SET(EPOLL_CTL_ADD, 1);
     }
   }
@@ -133,12 +124,7 @@ int picoev_update_events_internal(picoev_loop* _loop, int fd, int events)
   if ((events & PICOEV_READWRITE) == 0) {
     SET(EPOLL_CTL_DEL, 1);
   } else {
-    if (target->events == 0) {
-      ev.events |= EPOLLEXCLUSIVE;
-      SET(EPOLL_CTL_ADD, 1);
-    } else {
-      SET(EPOLL_CTL_MOD, 1);
-    }
+    SET(target->events == 0 ? EPOLL_CTL_ADD : EPOLL_CTL_MOD, 1);
   }
   
 #endif


### PR DESCRIPTION
Reverts mopemope/meinheld#68

There is one potential bug in current EPOLLEXCLUSIVE support.
See https://github.com/methane/uwsgi/commit/1fa66f1a7ec8881727d8e95faf2a3acab557fe98

I'll reimplement it later.