### PR TITLE
Fix chunked request fails with 411 length required

### DIFF
--- a/meinheld/server/http_request_parser.c
+++ b/meinheld/server/http_request_parser.c
@@ -1,4 +1,5 @@
 #include "http_request_parser.h"
+#include "http_parser.h"
 #include "server.h"
 #include "response.h"
 #include "input.h"
@@ -611,8 +612,9 @@ body_cb(http_parser *p, const char *buf, size_t len)
         return -1;
     }
     if(req->body_type == BODY_TYPE_NONE){
-        if(req->body_length == 0){
+        if(req->body_length == 0 && !(p->flags & F_CHUNKED)){
             //Length Required
+            DEBUG("set request code %d", 411);
             req->bad_request_code = 411;
             return -1;
         }

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,6 @@
 from meinheld import server
 import requests  # requests should not be pached
+import traceback
 from meinheld import patch
 patch.patch_all()
 import time
@@ -58,6 +59,8 @@ class ClientRunner(object):
                 r = self.func()
                 self.receive_data = r
                 self.environ = self.app.environ
+            except:
+                traceback.print_exc()
             finally:
                 if self.shutdown:
                     server.shutdown(1)

--- a/tests/test_wsgi_spec.py
+++ b/tests/test_wsgi_spec.py
@@ -168,6 +168,19 @@ def test_post():
     assert(res.content == ASSERT_RESPONSE)
     assert(env.get("wsgi.input").read() == b"key1=value1&key2=value2")
 
+def gen():
+    yield b"key1=value1&key2=value2"
+
+def test_post_chunked():
+
+    def client():
+        return requests.post("http://localhost:8000/", data=gen())
+
+    env, res = run_client(client, App)
+    assert(res.status_code == 200)
+    assert(res.content == ASSERT_RESPONSE)
+    assert(env.get("wsgi.input").read() == b"key1=value1&key2=value2")
+
 def test_upload_file():
 
     def client():


### PR DESCRIPTION
This fixes the failing unit test by checking whether the parser has set the `F_CHUNKED` flag and if-so, not rejecting requests without `Content-Length`.  At least I think that's what it should do.

This needs a solid review before merging.

Fixes #94.