### PR TITLE
Don't send Transfer-Encoding when no response body.

### DIFF
--- a/meinheld/server/http_request_parser.c
+++ b/meinheld/server/http_request_parser.c
@@ -396,7 +396,7 @@ get_http_header_key(const char *s, int len)
 static void
 key_upper(char *s, const char *key, size_t len)
 {
-    int i = 0;
+    size_t i = 0;
     int c;
     for (i = 0; i < len; i++) {
         c = key[i];
@@ -723,6 +723,7 @@ headers_complete_cb(http_parser *p)
         return -1;
     }
 
+    client->current_req->method = p->method;
     switch(p->method){
         case HTTP_DELETE:
             obj = http_method_delete;

--- a/meinheld/server/request.h
+++ b/meinheld/server/request.h
@@ -31,16 +31,17 @@ typedef struct {
 
     PyObject *environ;
     void *next;
+
+    int method;
     int body_length;
     int body_readed;
     int bad_request_code;
     void *body;
     request_body_type body_type;
-    
+
     PyObject *field;
     PyObject *value;
     uintptr_t start_msec;
-
 } request;
 
 typedef struct {

--- a/tests/test_wsgi_spec.py
+++ b/tests/test_wsgi_spec.py
@@ -220,3 +220,25 @@ def test_upgrade():
     assert(res.status_code == 101)
     assert(headers["upgrade"] == "websocket")
     assert(headers["connection"] == "upgrade")
+
+
+def test_no_content():
+
+    class App(BaseApp):
+        def __call__(self, environ, start_response):
+            status = "204 No Content"
+            response_headers = []
+            start_response(status, response_headers)
+            self.environ = environ.copy()
+            return []
+
+    def client():
+        return requests.get("http://localhost:8000")
+
+    env, res = run_client(client, App)
+    headers = res.headers
+    # print(env)
+    # print(res)
+    assert(res.status_code == 204)
+    assert("Content-Length" not in headers)
+    assert("Transfer-Encoding" not in headers)


### PR DESCRIPTION
Fixes #78.