### PR TITLE
Fix build breakage on CentOS 7.

### DIFF
--- a/meinheld/server/http_request_parser.c
+++ b/meinheld/server/http_request_parser.c
@@ -545,7 +545,9 @@ end:
  */
 static int check_field_name(const char *s, size_t len) {
   int ascii = 1;
-  for (int i = 0; i < len; i++) {
+  int i;
+
+  for (i = 0; i < len; i++) {
     if (s[i] > 127) {
       ascii = 0;
       break;


### PR DESCRIPTION
Builds on CentOS 7 fails with 

> 'for' loop initial declarations are only allowed in C99 mode

Fix this by not using an initial declaration.

(I'm guessing this works on other distributions due to different GCC versions with different defaults, but this is probably a safer change than to fiddle with compiler settings.)