### PR TITLE
greenlet version < 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ else:
     define_macros=[
             ("WITH_GREENLET",None),
             ("HTTP_PARSER_DEBUG", "0") ]
-    install_requires=['greenlet>=0.4.5,<0.5']
+    install_requires=['greenlet>=0.4.5,<2.0.0']
 
 if develop:
     define_macros.append(("DEVELOP",None))


### PR DESCRIPTION
greenlet < 0.5 conflicts with SQLAlchemy 1.4 which installs greenlet 1.0
the greenlet API should not have changed between 0.5 and < 2 according to 
https://github.com/benoitc/gunicorn/issues/2541#issuecomment-800353993